### PR TITLE
Remove environment types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,5 +159,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-!secrets/.env.example
 secrets/*
+!secrets/.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,3 @@ USER appuser
 COPY . .
 
 EXPOSE 8000
-
-# use .env.prod file for project configuration
-ENV ENV="prod"   

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,7 +9,7 @@ services:
     ports:
       - 8000:8000
     env_file:
-      - "secrets/.env.prod"
+      - "secrets/.env"
     depends_on:
       db:
         condition: service_healthy
@@ -31,7 +31,7 @@ services:
       timeout: 5s
       retries: 5
     env_file:
-      - "secrets/.env.prod"
+      - "secrets/.env"
 
   cache:
     image: redis:7.2-alpine
@@ -49,7 +49,7 @@ services:
       timeout: 5s
       retries: 5
     env_file:
-      - "secrets/.env.prod"
+      - "secrets/.env"
 
 
 volumes:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -12,7 +12,7 @@ from alembic import context
 
 
 config = context.config
-dotenv.load_dotenv("secrets/.env.prod")
+dotenv.load_dotenv("secrets/.env")
 dbt_dsn = os.getenv("DB_DSN")
 config.set_main_option("sqlalchemy.url", dbt_dsn)
 

--- a/src/url/settings.py
+++ b/src/url/settings.py
@@ -1,6 +1,5 @@
 """Module for project settings models."""
 from os import path
-from enum import StrEnum
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import networks
@@ -9,12 +8,6 @@ from pydantic import networks
 class Settings(BaseSettings):
     """Model for .env settings parsing."""
 
-    class _EnvType(StrEnum):
-        TEST = "test"
-        PROD = "prod"
-
-    env: _EnvType = "test"
-
     db_dsn: networks.PostgresDsn
     cache_dsn: networks.RedisDsn
 
@@ -22,6 +15,6 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_file_encoding="utf-8",
-        env_file=path.join(_project_dir, f"secrets/.env.{env}"),
+        env_file=path.join(_project_dir, "secrets/.env"),
         extra="ignore",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-import os
-
 import msgspec
 import pytest
 from litestar import Litestar
@@ -10,13 +8,8 @@ from src.url.settings import Settings
 from src.url.models.routers import URL, ShortenUrlRequest, ShortenUrlResponse
 from src.url.containers import Container
 from src.url.url_handlers import URLHandler
-from src.url.storage.db import URLRepository
-
 
 from .mocks.url_repositories import URLRepositoryMock, URLCacheRepositoryMock
-
-
-os.environ.setdefault("ENV", "test")  # use .env.test file for project configuration
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
At first it was several environment types: `prod` and `test`. And two .env file for each of them. 
I think it is overhead at least for now. So I removed this logic in order to make deployment more simple.